### PR TITLE
header text style support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,18 +92,18 @@ Check for complete example [here](https://github.com/rinku-k/rn-checkbox-list/bl
 
 ## Available props
 
-| Name              | Type         | Default                                                          | Description                                           |
-| ----------------- | ------------ | ---------------------------------------------------------------- | ----------------------------------------------------- |
-| listItems         | object array | []                                                               | List of checkboxes                                    |
-| selectedListItems | object array | []                                                               | List of selected items(subset of `listItems`)         |
-| headerName        | string       | ''                                                               | Shows header with the given name                      |
-| listItemStyle     | object       | {}                                                               | Each check list style                                 |
-| checkboxProp      | object       | {}                                                               | Custom checkbox style                                 |
-| textProp          | object       | `{ numberOfLines: 1, style: {fontSize: 14, color: '#626262',},}` | Props for checkbox Text component                     |
-| headerStyle       | object       | {}                                                               | Header check list style                               |
-| onChange          | function     | null                                                             | Fires on each checkbox select or deselect             |
-| onLoading         | function     | null                                                             | When the list is empty and a loader needs to be shown |
-| theme             | string       | #1A237E                                                          | Custom theme color for checkbox                       |
+| Name              | Type         | Default                                                                                                                                             | Description                                           |
+| ----------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| listItems         | object array | []                                                                                                                                                  | List of checkboxes                                    |
+| selectedListItems | object array | []                                                                                                                                                  | List of selected items(subset of `listItems`)         |
+| headerName        | string       | ''                                                                                                                                                  | Shows header with the given name                      |
+| listItemStyle     | object       | {}                                                                                                                                                  | Each check list style                                 |
+| checkboxProp      | object       | {}                                                                                                                                                  | Custom checkbox style                                 |
+| textProp          | object       | `{ numberOfLines: 1, style: {fontSize: 14, color: '#626262',},}`                                                                                    | Props for checkbox Text component                     |
+| headerStyle       | object       | `{ padding: 10, flexDirection: 'row', alignItems: 'center', backgroundColor: 'black', text: { color: 'white', fontWeight: 'bold', fontSize: 16,},}` | Header check list style                               |
+| onChange          | function     | null                                                                                                                                                | Fires on each checkbox select or deselect             |
+| onLoading         | function     | null                                                                                                                                                | When the list is empty and a loader needs to be shown |
+| theme             | string       | #1A237E                                                                                                                                             | Custom theme color for checkbox                       |
 
 ## Improvements
 

--- a/src/checkList.js
+++ b/src/checkList.js
@@ -137,7 +137,17 @@ CheckboxList.defaultProps = {
       color: '#626262',
     },
   },
-  headerStyle: {},
+  headerStyle: {
+    padding: 10,
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#F2F6FC',
+    text: {
+      color: '#212121',
+      fontWeight: 'bold',
+      fontSize: 16,
+    },
+  },
   onChange: () => {},
   onLoading: () => null,
   theme: '#1A237E',

--- a/src/checkListHeader.js
+++ b/src/checkListHeader.js
@@ -13,21 +13,11 @@ const CheckListHeader = ({
   isActive,
   theme,
 }) => (
-  <Touchable
-    onPress={onPress}
-    style={{
-      padding: 10,
-      flexDirection: 'row',
-      alignItems: 'center',
-      backgroundColor: '#F2F6FC',
-      ...style,
-    }}>
+  <Touchable onPress={onPress} style={{ ...style }}>
     <CheckBox theme={theme} isActive={isActive} checkboxProp={checkboxProp} />
     {!!text && (
       <View style={{ flex: 1 }}>
-        <Text
-          numberOfLines={1}
-          style={{ color: '#212121', fontWeight: 'bold', fontSize: 16 }}>
+        <Text numberOfLines={1} style={{ ...style.text }}>
           {text}
         </Text>
       </View>


### PR DESCRIPTION
Support for adding style for header text.
It leverages the headerStyle prop and Text styles can be added under "text' subject.

Eg:
```
headerStyle: {
    padding: 10,
    flexDirection: 'row',
    alignItems: 'center',
    backgroundColor: '#F2F6FC',
    text: {
      color: '#212121',
      fontWeight: 'bold',
      fontSize: 16,
    },
  },
```

Will add the information about this in the wiki.

resolves: #28 